### PR TITLE
Add hivemind backend

### DIFF
--- a/dalle_pytorch/distributed_backends/__init__.py
+++ b/dalle_pytorch/distributed_backends/__init__.py
@@ -1,4 +1,5 @@
 from .deepspeed_backend import DeepSpeedBackend
 from .distributed_backend import DistributedBackend
 from .dummy_backend import DummyBackend
+from .hivemind_backend import HivemindBackend
 from .horovod_backend import HorovodBackend

--- a/dalle_pytorch/distributed_backends/hivemind_backend.py
+++ b/dalle_pytorch/distributed_backends/hivemind_backend.py
@@ -1,0 +1,56 @@
+from .distributed_backend import DistributedBackend
+
+
+class HivemindBackend(DistributedBackend):
+    BACKEND_MODULE_NAME = 'hivemind'
+    BACKEND_NAME = 'hivemind'
+
+    def wrap_arg_parser(self, parser):
+        parser.add_argument('--initial_peers', type=str, nargs='+', default=None)
+        parser.add_argument('--experiment_prefix', type=str, default='dalle')
+        parser.add_argument('--batch_size_per_step', type=int, default=None)
+        parser.add_argument('--target_batch_size', type=int, default=None)
+        parser.add_argument('--target_group_size', type=int, default=None)
+        return parser
+
+    def _initialize(self):
+        pass
+
+    def _get_world_size(self):
+        return 1
+
+    def _get_rank(self):
+        return self.ROOT_RANK
+
+    def _get_local_rank(self):
+        return self.ROOT_RANK
+
+    def _local_barrier(self):
+        pass
+
+    def _distribute(
+        self,
+        args=None,
+        model=None,
+        optimizer=None,
+        _model_parameters=None,
+        training_data=None,
+        lr_scheduler=None,
+        **_kwargs,
+    ):
+        self.dht = self.backend_module.DHT(initial_peers=args.initial_peers, start=True)
+        print(f'DHT visible multiaddrs: {self.dht.get_visible_maddrs()}')
+        optimizer = self.backend_module.CollaborativeOptimizer(
+            optimizer,
+            dht=self.dht,
+            prefix=args.experiment_prefix,
+            batch_size_per_step=args.batch_size_per_step,
+            target_batch_size=args.target_batch_size,
+            target_group_size=args.target_group_size,
+            verbose=True,
+            start=True,
+        )
+        return model, optimizer, training_data, lr_scheduler
+
+    def _average_all(self, tensor):
+        return tensor

--- a/dalle_pytorch/distributed_utils.py
+++ b/dalle_pytorch/distributed_utils.py
@@ -14,6 +14,7 @@ function.
 from dalle_pytorch.distributed_backends import \
     DeepSpeedBackend, \
     DummyBackend, \
+    HivemindBackend, \
     HorovodBackend
 
 _DEFAULT_BACKEND = DummyBackend()
@@ -22,6 +23,7 @@ _DEFAULT_BACKEND = DummyBackend()
 BACKENDS = [
     _DEFAULT_BACKEND,
     DeepSpeedBackend(),
+    HivemindBackend(),
     HorovodBackend(),
 ]
 


### PR DESCRIPTION
This command runs training on a part of LAION-400M using hivemind as backend:

```bash
CUDA_VISIBLE_DEVICES=XXX python train_dalle.py \
  --image_text_folder https://YYY.tar --wds jpg,txt --truncate_captions \
  --distr_backend hivemind --batch_size_per_step 4 --target_batch_size 128 --target_group_size 2 \
  --initial_peers ZZZ
```

The `--initial_peers` argument may be omitted on the first peer.

![Screenshot 2021-10-15 at 23 40 11](https://user-images.githubusercontent.com/8748943/137555260-2057245c-652a-4563-8821-6673d33a523b.png)
